### PR TITLE
Add dry/wet mix slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,11 @@
                                     <span>Chaotic</span>
                                 </div>
                             </div>
+
+                            <div class="drywet-control">
+                                <h3>Dry/Wet Mix</h3>
+                                <input type="range" id="dry-wet" class="drywet-slider" min="0" max="100" value="50" step="1">
+                            </div>
                             
                             <div class="performance-effect-buttons">
                                 <button id="performance-randomize-btn">Randomize Effects</button>

--- a/main.js
+++ b/main.js
@@ -285,6 +285,15 @@ class ManosApp {
                 this.parameterMapper.setChaosLevel(chaosLevel);
             });
         }
+
+        // Dry/wet mix handler
+        const dryWetSlider = document.getElementById('dry-wet');
+        if (dryWetSlider) {
+            dryWetSlider.addEventListener('input', (e) => {
+                const mix = parseInt(e.target.value) / 100;
+                this.audioEngine.setDryWet(mix);
+            });
+        }
         
         this.performanceNextFileButton?.addEventListener('click', () => {
             this.nextAudioFileWithFade();
@@ -636,6 +645,13 @@ class ManosApp {
         /* @tweakable baseline volume level in dB */
         const baselineVolume = this.audioEngine.baselineVolume;
         console.log("Entering performance mode with baseline volume:", baselineVolume);
+
+        // Apply initial dry/wet value from slider
+        const dryWetSlider = document.getElementById('dry-wet');
+        if (dryWetSlider) {
+            const mix = parseInt(dryWetSlider.value) / 100;
+            this.audioEngine.setDryWet(mix);
+        }
         
         // Ensure audio is ready for performance mode
         try {

--- a/styles.css
+++ b/styles.css
@@ -295,6 +295,41 @@ main {
     color: var(--primary-dark);
 }
 
+/* Dry/wet slider */
+.drywet-control {
+    margin: 20px 0;
+    padding: 15px;
+    background-color: var(--secondary-color);
+    border-radius: var(--card-radius);
+    border: 1px solid var(--primary-light);
+}
+
+.drywet-control h3 {
+    color: var(--primary-dark);
+    margin-bottom: 10px;
+}
+
+.drywet-slider {
+    width: 100%;
+    height: 8px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: linear-gradient(to right, var(--primary-light), var(--accent-color));
+    outline: none;
+    border-radius: 4px;
+}
+
+.drywet-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--primary-color);
+    cursor: pointer;
+    border: 2px solid white;
+}
+
 /* Performance mode styles */
 .performance-controls {
     background-color: var(--secondary-color);


### PR DESCRIPTION
## Summary
- add global crossfade for dry/wet mixing in AudioEngine
- expose setDryWet and handle in app logic
- include Dry/Wet slider in performance UI
- style the new slider

## Testing
- `node --check main.js`
- `node --check audioEngine.js`
- `node --check handTracking.js`
- `node --check parameterMapper.js`
- *(fails: running `node -e "require('./audioEngine.js');"` due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68442a1b0a98832798b474a757d0cfa1